### PR TITLE
Proper support for mongoengine choices attribute.

### DIFF
--- a/marshmallow_mongoengine/conversion/params.py
+++ b/marshmallow_mongoengine/conversion/params.py
@@ -78,8 +78,11 @@ class ChoiceParam(MetaParam):
     def __init__(self, field_me):
         super(ChoiceParam, self).__init__()
         choices = getattr(field_me, 'choices', None)
+        labels = None
+        if choices and isinstance(choices[0], (list, tuple)):
+            choices, labels = zip(*choices)
         if choices:
-            self.field_kwargs['validate'].append(validate.OneOf(choices))
+            self.field_kwargs['validate'].append(validate.OneOf(choices, labels))
 
 
 class PrecisionParam(MetaParam):

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -76,3 +76,21 @@ class TestParams(BaseTest):
         assert not errors
         assert doc.field_with_default == 'default_value'
         assert doc.field_required_with_default == 'default_generated_value'
+
+    def test_choices(self):
+        class Doc(me.Document):
+            CHOICES = (
+                (0, 'zero'),
+                (1, 'one'),
+            )
+            basic = me.IntField(choices=CHOICES)
+
+        class DocSchema(ModelSchema):
+            class Meta:
+                model = Doc
+        doc, errors = DocSchema().load({'basic': 0})
+        assert not errors
+        assert doc.basic == 0
+
+        doc, errors = DocSchema().load({'basic': 3})
+        assert errors == {'basic': ['Not a valid choice.']}


### PR DESCRIPTION
Same behavior as in mongoengine:
https://github.com/MongoEngine/mongoengine/blob/3d755738897f8e5a6a8306edb8ec9d436171703f/mongoengine/base/fields.py#L195-L197