### PR TITLE
Fixing schema update() method in light of recent changes in marshmall…

### DIFF
--- a/marshmallow_mongoengine/fields.py
+++ b/marshmallow_mongoengine/fields.py
@@ -144,9 +144,7 @@ class GenericEmbeddedDocument(fields.Field):
 
             class Meta:
                 model = type(value)
-        data, errors = NestedSchema().dump(value)
-        if errors:
-            raise ValidationError(errors)
+        data = NestedSchema().dump(value)
         return data
 
 
@@ -165,9 +163,7 @@ class Map(fields.Field):
         func = getattr(self.schema, action)
         total = {}
         for k, v in value.items():
-            data, errors = func(v)
-            if errors:
-                raise ValidationError(errors)
+            data = func(v)
             total[k] = data
         return total
 

--- a/marshmallow_mongoengine/schema.py
+++ b/marshmallow_mongoengine/schema.py
@@ -147,14 +147,14 @@ class ModelSchema(with_metaclass(SchemaMeta, ma.Schema)):
         required_fields = [k for k, f in self.fields.items() if f.required]
         for field in required_fields:
             self.fields[field].required = False
-        loaded_data, errors = self._do_load(data, postprocess=False)
+        loaded_data = self._do_load(data, postprocess=False)
         for field in required_fields:
             self.fields[field].required = True
-        if not errors:
+        if loaded_data:
             # Update the given obj fields
             for k, v in loaded_data.items():
                 # Skip default values that have been automatically
                 # added during unserialization
                 if k in data:
                     setattr(obj, k, v)
-        return ma.UnmarshalResult(data=obj, errors=errors)
+        return obj

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     install_requires=['mongoengine>=0.9.0'],
     extras_require={
         'toasted': ['toastedmarshmallow>=0.2.6'],
-        'marshmallow': ['marshmallow>=2.1.0'],
+        'marshmallow': ['marshmallow>=3.0.0b7'],
     },
     license='MIT',
     zip_safe=False,

--- a/tests/test_skip.py
+++ b/tests/test_skip.py
@@ -35,9 +35,9 @@ class TestSkip(BaseTest):
             class Meta:
                 model = Doc
         doc = Doc()
-        dump = DocSchema().dump(doc)
-        assert not dump.errors
-        assert dump.data == {'field_not_empty': 'value'}
+        data = DocSchema().dump(doc)
+        assert data
+        assert data == {'field_not_empty': 'value'}
 
     def test_disable_skip_none_field(self):
         class Doc(me.Document):
@@ -48,6 +48,5 @@ class TestSkip(BaseTest):
                 model = Doc
                 model_skip_values = ()
         doc = Doc()
-        data, errors = DocSchema().dump(doc)
-        assert not errors
+        data = DocSchema().dump(doc)
         assert data == {'field_empty': None, 'list_empty': []}


### PR DESCRIPTION
Marshmallow 3.0.0b7 changed function outputs in a breaking manner.  One such [change](https://github.com/marshmallow-code/marshmallow/commit/389a38d6cb0a04cdfc93d788224a593cc2b3d3fa#diff-035365c88325ed9779fcb020f7bcb35a) was the removal of the UnmarshalResult namedtuple in conjunction with better exception handling  Functions that used to return an UnmarshalResult now just the data object instead of a data, errors pair.

In marshmallow-mongoengine, these changes break the update method in BaseSchema.  There may be other things that need fixing, but I saw no way to raise the issue, so I've created this pull request instead.