### PR TITLE
Fix GenericReference._serialize() returns a bson.ObjectID and not a str

### DIFF
--- a/marshmallow_mongoengine/fields.py
+++ b/marshmallow_mongoengine/fields.py
@@ -122,7 +122,7 @@ class GenericReference(fields.Field):
         # Only return the pk of the document for serialization
         if value is None:
             return missing
-        return value.pk
+        return str(value.pk) if isinstance(value.pk, bson.ObjectId) else value.pk
 
 
 class GenericEmbeddedDocument(fields.Field):


### PR DESCRIPTION
This fixes an issue already reported by @beager on touilleMan/marshmallow-mongoengine#16 (before this repo was forked from there)  that I got bitten by, too.

Tested it on my project and it works fine.  It would be nice to see this merged sometime soon, since I'm installing this from my repo now.

Thanks!