### PR TITLE
Fixed issue with UUID pk in ReferenceField

### DIFF
--- a/marshmallow_mongoengine/fields.py
+++ b/marshmallow_mongoengine/fields.py
@@ -1,4 +1,5 @@
 import bson
+import uuid
 from marshmallow import ValidationError, fields, missing
 from mongoengine import ValidationError as MongoValidationError, NotRegistered
 from mongoengine.base import get_document
@@ -71,7 +72,7 @@ class Reference(fields.Field):
         # Only return the pk of the document for serialization
         if value is None:
             return missing
-        return str(value.pk) if isinstance(value.pk, bson.ObjectId) else value.pk
+        return str(value.pk) if isinstance(value.pk, (bson.ObjectId, uuid.UUID)) else value.pk
 
 
 class GenericReference(fields.Field):


### PR DESCRIPTION
When serializing a ReferenceField that uses a UUID as primary key, the serializer wont convert the UUID to a string. The created dictionary is therefore not JSON serializable and throws an exception "TypeError: Object of type UUID is not JSON serializable".

Code to reproduce this:

```
import json
from uuid import uuid4

from marshmallow_mongoengine import ModelSchema
from mongoengine import *


class User(Document):
    id = UUIDField(primary_key=True, default=uuid4)
    parent = ReferenceField('User')


class UserSchema(ModelSchema):
    class Meta:
        model = User


parent = User()
user = User(parent=parent)

data = UserSchema().dump(user).data
print(json.dumps(data))
```