### PR TITLE
Pipy GitHub action

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -18,7 +18,7 @@ jobs:
   build-n-publish:
     name: Build and publish Python distributions to PyPI and TestPyPI
     runs-on: ubuntu-latest
-    needs: [linting]
+    needs: [lint]
     if: github.event_name == 'create' && startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -14,3 +14,28 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: psf/black@stable
+
+  build-n-publish:
+    name: Build and publish Python distributions to PyPI and TestPyPI
+    runs-on: ubuntu-latest
+    needs: [linting]
+    if: github.event_name == 'create' && startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.7"
+      - name: Build wheel for PyPI and TestPyPI
+        run: |
+          pip install wheel
+          python setup.py sdist bdist_wheel
+      - name: Publish distribution to Test PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This PR adds the GitHub action to automatically build and publish to PyPI (and TestPyPI) on version tag creation. It depends on two repository secrets that have already been added to the project.

There isn't yet a step for running tests (they depend on a running MongoDB, so it's not super-straightforward to set up), so I am considering that maybe we should hold on this PR until tests are also automated and set as a dependency of this step. Thoughts?