### PR TITLE
Use the `metadata` kwarg to avoid deprecation warnings

### DIFF
--- a/marshmallow_mongoengine/conversion/params.py
+++ b/marshmallow_mongoengine/conversion/params.py
@@ -69,7 +69,7 @@ class DescriptionParam(MetaParam):
         super(DescriptionParam, self).__init__()
         description = getattr(field_me, "help_text", None)
         if description:
-            self.field_kwargs["description"] = description
+            self.field_kwargs.setdefault("metadata", {})["description"] = description
 
 
 class AllowNoneParam(MetaParam):

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     packages=find_packages(exclude=("test*",)),
     package_dir={"marshmallow-mongoengine": "marshmallow-mongoengine"},
     include_package_data=True,
-    install_requires=["mongoengine>=0.9.0", "marshmallow>=3.0.0b7"],
+    install_requires=["mongoengine>=0.9.0", "marshmallow>=3.10.0"],
     license="MIT",
     zip_safe=False,
     keywords="mongoengine marshmallow",


### PR DESCRIPTION
Change the `description` param to use instead be `metadata`.`description`, as description is deprecated.

Prevents the following deprecation warning from appearing: `RemovedInMarshmallow4Warning: Passing field metadata as keyword arguments is deprecated. Use the explicit 'metadata=...' argument instead. Additional metadata: ...`