### PR TITLE
add enum field support

### DIFF
--- a/marshmallow_mongoengine/conversion/fields.py
+++ b/marshmallow_mongoengine/conversion/fields.py
@@ -175,7 +175,6 @@ register_field(me.fields.BooleanField, ma_fields.Boolean)
 register_field(me.fields.ComplexDateTimeField, ma_fields.DateTime)
 register_field(me.fields.DateField, ma_fields.Date)
 register_field(me.fields.DateTimeField, ma_fields.DateTime)
-register_field(me.fields.EnumField, ma_fields.Enum)
 register_field(
     me.fields.DecimalField,
     ma_fields.Decimal,

--- a/marshmallow_mongoengine/conversion/fields.py
+++ b/marshmallow_mongoengine/conversion/fields.py
@@ -222,11 +222,11 @@ register_field(
 register_field(
     me.fields.URLField, ma_fields.URL, available_params=(params.LengthParam,)
 )
+register_field_builder(me.fields.EnumField, EnumBuilder)
 register_field_builder(me.fields.EmbeddedDocumentField, EmbeddedDocumentBuilder)
 register_field_builder(me.fields.ListField, ListBuilder)
 register_field_builder(me.fields.MapField, MapBuilder)
 register_field_builder(me.fields.SortedListField, ListBuilder)
-register_field_builder(me.fields.EnumField, EnumBuilder)
 # TODO: finish fields...
 # me.fields.GeoPointField: ma_fields.GeoPoint,
 # me.fields.PolygonField: ma_fields.Polygon,

--- a/marshmallow_mongoengine/conversion/fields.py
+++ b/marshmallow_mongoengine/conversion/fields.py
@@ -68,7 +68,7 @@ class EnumBuilder(MetaFieldBuilder):
 
     def _get_marshmallow_field_cls(self):
         return functools.partial(
-            self.MARSHMALLOW_FIELD_CLS, self.mongoengine_field.enum
+            self.MARSHMALLOW_FIELD_CLS, self.mongoengine_field._enum_cls
         )
 
 

--- a/marshmallow_mongoengine/conversion/fields.py
+++ b/marshmallow_mongoengine/conversion/fields.py
@@ -62,6 +62,16 @@ class ListBuilder(MetaFieldBuilder):
         )
 
 
+class EnumBuilder(MetaFieldBuilder):
+    AVAILABLE_PARAMS = ()
+    MARSHMALLOW_FIELD_CLS = ma_fields.Enum
+
+    def _get_marshmallow_field_cls(self):
+        return functools.partial(
+            self.MARSHMALLOW_FIELD_CLS, self.mongoengine_field.enum
+        )
+
+
 class ReferenceBuilder(MetaFieldBuilder):
     AVAILABLE_PARAMS = ()
     MARSHMALLOW_FIELD_CLS = ma_fields.Reference
@@ -217,6 +227,7 @@ register_field_builder(me.fields.EmbeddedDocumentField, EmbeddedDocumentBuilder)
 register_field_builder(me.fields.ListField, ListBuilder)
 register_field_builder(me.fields.MapField, MapBuilder)
 register_field_builder(me.fields.SortedListField, ListBuilder)
+register_field_builder(me.fields.EnumField, EnumBuilder)
 # TODO: finish fields...
 # me.fields.GeoPointField: ma_fields.GeoPoint,
 # me.fields.PolygonField: ma_fields.Polygon,

--- a/marshmallow_mongoengine/conversion/fields.py
+++ b/marshmallow_mongoengine/conversion/fields.py
@@ -165,6 +165,7 @@ register_field(me.fields.BooleanField, ma_fields.Boolean)
 register_field(me.fields.ComplexDateTimeField, ma_fields.DateTime)
 register_field(me.fields.DateField, ma_fields.Date)
 register_field(me.fields.DateTimeField, ma_fields.DateTime)
+register_field(me.fields.EnumField, ma_fields.Enum)
 register_field(
     me.fields.DecimalField,
     ma_fields.Decimal,


### PR DESCRIPTION
Marshmallow has added native support for Enums which makes the conversion from ``me.EnumField`` to ``ma.Enum`` very straightforward. See https://marshmallow.readthedocs.io/en/stable/marshmallow.fields.html#marshmallow.fields.Enum.

Addresses issue #20 